### PR TITLE
Replace size() with empty() whenever possible

### DIFF
--- a/src/geojsonvt.cpp
+++ b/src/geojsonvt.cpp
@@ -85,7 +85,7 @@ void GeoJSONVT::splitTile(std::vector<ProjectedFeature> features_,
     std::queue<FeatureStackItem> stack;
     stack.emplace(features_, z_, x_, y_);
 
-    while (stack.size()) {
+    while (!stack.empty()) {
         FeatureStackItem set = stack.front();
         stack.pop();
         std::vector<ProjectedFeature> features = std::move(set.features);
@@ -169,12 +169,12 @@ void GeoJSONVT::splitTile(std::vector<ProjectedFeature> features_,
         const auto right =
             Clip::clip(features, z2, x + k2, x + k4, 0, intersectX, tile->min.x, tile->max.x);
 
-        if (left.size()) {
+        if (!left.empty()) {
             tl = Clip::clip(left, z2, y - k1, y + k3, 1, intersectY, tile->min.y, tile->max.y);
             bl = Clip::clip(left, z2, y + k2, y + k4, 1, intersectY, tile->min.y, tile->max.y);
         }
 
-        if (right.size()) {
+        if (!right.empty()) {
             tr = Clip::clip(right, z2, y - k1, y + k3, 1, intersectY, tile->min.y, tile->max.y);
             br = Clip::clip(right, z2, y + k2, y + k4, 1, intersectY, tile->min.y, tile->max.y);
         }
@@ -183,16 +183,16 @@ void GeoJSONVT::splitTile(std::vector<ProjectedFeature> features_,
             Time::timeEnd("clipping");
         }
 
-        if (tl.size()) {
+        if (!tl.empty()) {
             stack.emplace(std::move(tl), z + 1, x * 2, y * 2);
         }
-        if (bl.size()) {
+        if (!bl.empty()) {
             stack.emplace(std::move(bl), z + 1, x * 2, y * 2 + 1);
         }
-        if (tr.size()) {
+        if (!tr.empty()) {
             stack.emplace(std::move(tr), z + 1, x * 2 + 1, y * 2);
         }
-        if (br.size()) {
+        if (!br.empty()) {
             stack.emplace(std::move(br), z + 1, x * 2 + 1, y * 2 + 1);
         }
     }
@@ -233,7 +233,7 @@ Tile& GeoJSONVT::getTile(uint8_t z, uint32_t x, uint32_t y) {
     }
 
     // if we found a parent tile containing the original geometry, we can drill down from it
-    if (parent->source.size()) {
+    if (!parent->source.empty()) {
         if (isClippedSquare(parent->features, extent, buffer)) {
             return transformTile(*parent, extent);
         }

--- a/src/geojsonvt_clip.cpp
+++ b/src/geojsonvt_clip.cpp
@@ -55,7 +55,7 @@ std::vector<ProjectedFeature> Clip::clip(const std::vector<ProjectedFeature>& fe
                                   intersect, (type == ProjectedFeatureType::Polygon));
         }
 
-        if (slices.members.size()) {
+        if (!slices.members.empty()) {
             // if a feature got clipped, it will likely get clipped on the next zoom level as well,
             // so there's no need to recalculate bboxes
             clipped.emplace_back(slices, type, feature.tags, feature.min, feature.max);
@@ -154,7 +154,7 @@ ProjectedGeometryContainer Clip::clipGeometry(const ProjectedGeometryContainer& 
         }
 
         // close the polygon if its endpoints are not the same after clipping
-        if (closed && slice.members.size()) {
+        if (closed && !slice.members.empty()) {
             const auto& first = slice.members.front().get<ProjectedPoint>();
             const auto& last = slice.members.back().get<ProjectedPoint>();
             if (first != last) {
@@ -174,7 +174,7 @@ ProjectedGeometryContainer Clip::newSlice(ProjectedGeometryContainer& slices,
                                           double area,
                                           double dist) {
 
-    if (slice.members.size()) {
+    if (!slice.members.empty()) {
         // we don't recalculate the area/length of the unclipped geometry because the case where it
         // goes below the visibility threshold as a result of clipping is rare, so we avoid doing
         // unnecessary work

--- a/src/geojsonvt_simplify.cpp
+++ b/src/geojsonvt_simplify.cpp
@@ -45,17 +45,13 @@ void Simplify::simplify(ProjectedGeometryContainer& points, double tolerance) {
             stack.push(index);
             first = index;
         } else {
-            if (stack.size()) {
+            if (!stack.empty()) {
                 last = stack.top();
                 stack.pop();
-            } else {
-                last = 0;
-            }
-
-            if (stack.size()) {
                 first = stack.top();
                 stack.pop();
             } else {
+                last = 0;
                 first = 0;
             }
         }

--- a/src/geojsonvt_tile.cpp
+++ b/src/geojsonvt_tile.cpp
@@ -78,7 +78,7 @@ Tile::addFeature(Tile& tile, const ProjectedFeature& feature, double tolerance, 
         }
     }
 
-    if (simplified.size()) {
+    if (!simplified.empty()) {
         tile.features.push_back(TileFeature(simplified, type, feature.tags));
     }
 }

--- a/src/geojsonvt_wrap.cpp
+++ b/src/geojsonvt_wrap.cpp
@@ -12,16 +12,16 @@ std::vector<ProjectedFeature> Wrap::wrap(std::vector<ProjectedFeature>& features
     // right world copy
     const auto right = Clip::clip(features, 1, 1 - buffer, 2 + buffer, 0, intersectX, -1, 2);
 
-    if (left.size() || right.size()) {
+    if (!left.empty() || !right.empty()) {
         // center world copy
         auto merged = Clip::clip(features, 1, -buffer, 1 + buffer, 0, intersectX, -1, 2);
 
-        if (left.size()) {
+        if (!left.empty()) {
             // merge left into center
             const auto shifted = shiftFeatureCoords(left, 1);
             merged.insert(merged.begin(), shifted.begin(), shifted.end());
         }
-        if (right.size()) {
+        if (!right.empty()) {
             // merge right into center
             const auto shifted = shiftFeatureCoords(right, -1);
             merged.insert(merged.end(), shifted.begin(), shifted.end());


### PR DESCRIPTION
Before C++11, std::list's implementation of `size()` was O(n). It should be all O(1) now, but it is probably still a good idea to use `empty()` to emphasise the intend.

Follows mapbox/mapbox-gl-native#1842.

/cc @kkaefer @mourner @incanus