### PR TITLE
Expose inline ProjectedPoint constructor

### DIFF
--- a/include/mapbox/geojsonvt/geojsonvt.hpp
+++ b/include/mapbox/geojsonvt/geojsonvt.hpp
@@ -17,16 +17,14 @@ class GeoJSONVT {
 public:
     static std::vector<ProjectedFeature> convertFeatures(const std::string& data,
                                                          uint8_t maxZoom = 14,
-                                                         double tolerance = 3,
-                                                         bool debug = false);
+                                                         double tolerance = 3);
 
     GeoJSONVT(std::vector<ProjectedFeature> features_,
               uint8_t maxZoom = 14,
               uint8_t indexMaxZoom = 5,
               uint32_t indexMaxPoints = 100000,
               bool solidChildren = false,
-              double tolerance = 3,
-              bool debug = false);
+              double tolerance = 3);
 
     const Tile& getTile(uint8_t z, uint32_t x, uint32_t y);
 
@@ -79,7 +77,6 @@ private:
     const uint32_t indexMaxPoints; // max number of points per tile in the tile index
     const bool solidChildren;      // whether to tile solid square tiles further
     const double tolerance;        // simplification tolerance (higher means simpler)
-    const bool debug;
     const uint16_t extent = 4096;  // tile extent
     const uint8_t buffer = 64;     // tile buffer on each side
     std::map<uint64_t, Tile> tiles;

--- a/include/mapbox/geojsonvt/geojsonvt_types.hpp
+++ b/include/mapbox/geojsonvt/geojsonvt_types.hpp
@@ -35,7 +35,7 @@ using ProjectedGeometry =
 
 class ProjectedPoint {
 public:
-    inline ProjectedPoint(double x_ = -1, double y_ = -1, double z_ = -1) : x(x_), y(y_), z(z_) {
+    inline __attribute__((visibility("default"))) ProjectedPoint(double x_ = -1, double y_ = -1, double z_ = -1) : x(x_), y(y_), z(z_) {
     }
 
     inline bool isValid() const {

--- a/src/geojsonvt.cpp
+++ b/src/geojsonvt.cpp
@@ -74,7 +74,7 @@ GeoJSONVT::GeoJSONVT(std::vector<ProjectedFeature> features_,
             printf("features: %i, points: %i\n", tiles[0].numFeatures, tiles[0].numPoints);
         }
         Time::timeEnd("generate tiles");
-        printf("tiles generated: %i {\n", total);
+        printf("tiles generated: %i {\n", static_cast<int>(total));
         for (const auto& pair : stats) {
             printf("    z%i: %i\n", pair.first, pair.second);
         }

--- a/src/geojsonvt_convert.cpp
+++ b/src/geojsonvt_convert.cpp
@@ -20,7 +20,6 @@ std::vector<ProjectedFeature> Convert::convert(const JSDocument& data, double to
         if (data.HasMember("features")) {
             const JSValue& rawFeatures = data["features"];
             if (rawFeatures.IsArray()) {
-                printf("there are %i total features to convert\n", rawFeatures.Size());
                 for (rapidjson::SizeType i = 0; i < rawFeatures.Size(); ++i) {
                     convertFeature(features, rawFeatures[i], tolerance);
                 }
@@ -33,7 +32,6 @@ std::vector<ProjectedFeature> Convert::convert(const JSDocument& data, double to
         if (data.HasMember("geometries")) {
             const JSValue& rawGeometries = data["geometries"];
             if (rawGeometries.IsArray()) {
-                printf("there are %i total geometries to convert\n", rawGeometries.Size());
                 Tags tags;
                 for (rapidjson::SizeType i = 0; i < rawGeometries.Size(); ++i) {
                     convertGeometry(features, tags, rawGeometries[i], tolerance);

--- a/test/test_full.cpp
+++ b/test/test_full.cpp
@@ -32,10 +32,16 @@ std::map<std::string, std::vector<TileFeature>> genTiles(const std::string& data
 }
 
 struct Arguments {
+    Arguments(const std::string inputFile_, const std::string expectedFile_, const uint32_t maxZoom_ = 0, const uint32_t maxPoints_ = 10000)
+    : inputFile(inputFile_),
+    expectedFile(expectedFile_),
+    maxZoom(maxZoom_),
+    maxPoints(maxPoints_) {};
+    
     const std::string inputFile;
     const std::string expectedFile;
-    const uint32_t maxZoom = 0;
-    const uint32_t maxPoints = 10000;
+    const uint32_t maxZoom;
+    const uint32_t maxPoints;
 };
 
 


### PR DESCRIPTION
So that it doesn't get hidden by default [mason](https://github.com/mapbox/mason) flag `-fvisibility-inlines-hidden` on OS X.

- Fixes GCC finickiness around initializer lists by adding an explicit `Arguments` constructor in `test/test_full.cpp`.
- Fixes compiler warning with `static_cast<int>` for picky `printf` statement.
- Fixes https://github.com/mapbox/geojson-vt-cpp/issues/5, drops `bool debug` from public api, uses `#ifdef DEBUG` instead.

/cc @kkaefer 