### PR TITLE
Revert "expose inline ProjectedPoint constructor"

### DIFF
--- a/include/mapbox/geojsonvt/geojsonvt_types.hpp
+++ b/include/mapbox/geojsonvt/geojsonvt_types.hpp
@@ -35,7 +35,7 @@ using ProjectedGeometry =
 
 class ProjectedPoint {
 public:
-    inline __attribute__((visibility("default"))) ProjectedPoint(double x_ = -1, double y_ = -1, double z_ = -1) : x(x_), y(y_), z(z_) {
+    inline ProjectedPoint(double x_ = -1, double y_ = -1, double z_ = -1) : x(x_), y(y_), z(z_) {
     }
 
     inline bool isValid() const {


### PR DESCRIPTION
This reverts commit ebd99d1e9edbe629ae65ef4223a454b7cd56a73a.

This ended up not being necessary, https://github.com/mapbox/mapbox-gl-native/pull/2584 is working (with no missing label bug on OS X) without this change.

/cc @kkaefer @incanus 