### PR TITLE
GCC_SYMBOLS_PRIVATE_EXTERN

### DIFF
--- a/deps/common.gypi
+++ b/deps/common.gypi
@@ -11,19 +11,21 @@
         'xcode_settings': {
           'GCC_OPTIMIZATION_LEVEL': '0',
           'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES',
-          'DEAD_CODE_STRIPPING': 'NO',
           'GCC_INLINES_ARE_PRIVATE_EXTERN': 'NO',
+          'GCC_SYMBOLS_PRIVATE_EXTERN': 'NO',
+          'DEAD_CODE_STRIPPING': 'NO',
           'OTHER_CPLUSPLUSFLAGS': [ '-std=c++1y', '-fno-omit-frame-pointer','-fwrapv', '-fstack-protector-all', '-fno-common'],
         }
       },
       'Release': {
-        'cflags_cc': [ '-g', '-O3', '-std=c++1y' ],
+        'cflags_cc': [ '-g', '-O3', '-std=c++1y', '-fvisibility=hidden' ],
         'defines': [ 'NDEBUG' ],
         'xcode_settings': {
           'GCC_OPTIMIZATION_LEVEL': '3',
           'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES',
+          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
+          'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',
           'DEAD_CODE_STRIPPING': 'NO',
-          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'NO',
           'OTHER_CPLUSPLUSFLAGS': [ '-std=c++1y' ],
         }
       },


### PR DESCRIPTION
To hide internal RapidJSON symbols when building [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native) (which also uses RapidJSON directly).

Refs https://github.com/mapbox/mapbox-gl-native/pull/2584

/cc @jfirebaugh @kkaefer