### PR TITLE
Check variant type in Convert::calcRingBBox

### DIFF
--- a/src/geojsonvt_convert.cpp
+++ b/src/geojsonvt_convert.cpp
@@ -307,11 +307,13 @@ void Convert::calcRingBBox(ProjectedPoint& minPoint,
                            ProjectedPoint& maxPoint,
                            const ProjectedGeometryContainer& geometry) {
     for (auto& member : geometry.members) {
-        auto& p = member.get<ProjectedPoint>();
-        minPoint.x = std::min(p.x, minPoint.x);
-        maxPoint.x = std::max(p.x, maxPoint.x);
-        minPoint.y = std::min(p.y, minPoint.y);
-        maxPoint.y = std::max(p.y, maxPoint.y);
+        if (member.is<ProjectedPoint>()) {
+            auto& p = member.get<ProjectedPoint>();
+            minPoint.x = std::min(p.x, minPoint.x);
+            maxPoint.x = std::max(p.x, maxPoint.x);
+            minPoint.y = std::min(p.y, minPoint.y);
+            maxPoint.y = std::max(p.y, maxPoint.y);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #18.

Confirms `ProjectedGeometryContainer` members are `ProjectedPoint` before modifying bbox min/max to fix crash in https://github.com/mapbox/mapbox-gl-native/issues/2926

This should discard nested polygons, which I think should be safe to throw out when calculating the bounding box. Should we add a test to confirm this works as expected?

/cc @jfirebaugh @mourner for review