### PR TITLE
Basic optimisations pass:

### DIFF
--- a/include/mapbox/geojsonvt/convert.hpp
+++ b/include/mapbox/geojsonvt/convert.hpp
@@ -26,7 +26,7 @@ public:
     static std::vector<ProjectedFeature> convert(const JSValue& data, double tolerance);
 
     static ProjectedFeature
-    create(Tags tags, ProjectedFeatureType type, ProjectedGeometry geometry);
+    create(Tags tags, ProjectedFeatureType type, ProjectedGeometry const& geometry);
 
     static ProjectedRing projectRing(const std::vector<LonLat>& lonlats, double tolerance = 0);
 


### PR DESCRIPTION
* Avoid converting raw character buffers to std::string prior comparing, use native `rapidjson::GenericValue<>` vs string literal operator==().
* Don't rely on compiler optimising loops like `for (size_t i = 0; i < cont.siez() ; ++i)` - prefer
```c++
size_t size = cont.size();
for (size_t i = 0; i < size ; ++i) {}
```
* pass ProjectedGeometry by const reference: `create(Tags tags, ProjectedFeatureType type, ProjectedGeometry const& geometry);`

(ref http://rapidjson.org/md_doc_tutorial.html#ValueDocument)