### PR TITLE
Split geometry collections into separate features

### DIFF
--- a/include/mapbox/geojsonvt.hpp
+++ b/include/mapbox/geojsonvt.hpp
@@ -27,18 +27,7 @@ struct ToFeatureCollection {
         return { value };
     }
     feature_collection operator()(const geometry& value) const {
-        if (value.is<geometry_collection>()) {
-            geometry_collection collection = std::move(value.get<geometry_collection>());
-            feature_collection features;
-            features.reserve(collection.size());
-            for (const auto& geom : collection) {
-                feature feat{ geom };
-                features.emplace_back(std::move(feat));
-            }
-            return features;
-        } else {
-            return { { value } };
-        }
+        return { { value } };
     }
 };
 


### PR DESCRIPTION
A follow-up to #50.

Makes the behavior match the JS version, which splits geometry collections into individual features (even when they were inside another feature). Prior to this PR, top-level geometry collections would be split, but collections inside features would not.

cc @yhahn @jfirebaugh 