### PR TITLE
Fix compilation errors with libc++ on QNX 7

### DIFF
--- a/include/mapbox/geojsonvt/types.hpp
+++ b/include/mapbox/geojsonvt/types.hpp
@@ -60,13 +60,19 @@ using vt_multi_point = std::vector<vt_point>;
 
 struct vt_line_string : std::vector<vt_point> {
     using container_type = std::vector<vt_point>;
-    using container_type::container_type;
+    vt_line_string() = default;
+    vt_line_string(std::initializer_list<vt_point> args)
+      : container_type(std::move(args)) {}
+
     double dist = 0.0; // line length
 };
 
 struct vt_linear_ring : std::vector<vt_point> {
     using container_type = std::vector<vt_point>;
-    using container_type::container_type;
+    vt_linear_ring() = default;
+    vt_linear_ring(std::initializer_list<vt_point> args)
+      : container_type(std::move(args)) {}
+
     double area = 0.0; // polygon ring area
 };
 


### PR DESCRIPTION
QNX 7 compiler (i.e qcc based GCC 5.4.0 with libc++ from LLVM) has a limited c++11 feature support and causing the compilation errors with the inheriting constructors.

compilation errors on QNX 7:
```
mapbox-gl-native/deps/geojsonvt/6.3.0/include/mapbox/geojsonvt/types.hpp:66:27: error: 'template<class _InputIterator> mapbox::geojsonvt::detail::vt_line_string::vt_line_string(_InputIterator, _InputIterator, const allocator_type&)' inherited from 'std::__1::vector<mapbox::geojsonvt::detail::vt_point>'
     using container_type::container_type;
                           ^
mapbox-gl-native/deps/geojsonvt/6.3.0/include/mapbox/geojsonvt/types.hpp:66:27: error: conflicts with version inherited from 'std::__1::vector<mapbox::geojsonvt::detail::vt_point>'
```

This patch fixes the issues by providing the required constructors explicitly.