### PR TITLE
Fix test build on GCC 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -I include -std=c++14 -Wall -Wextra
+CXXFLAGS += -I include -std=c++14 -Wall -Wextra -D_GLIBCXX_USE_CXX11_ABI=0
 RELEASE_FLAGS ?= -O3 -DNDEBUG
 DEBUG_FLAGS ?= -g -O0 -DDEBUG
 


### PR DESCRIPTION
This patch fixes linking errors caused by the `libgtest.a` ABI incompatibilities.

https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html