### PR TITLE
use ::hypot from libc instead of the STL version

### DIFF
--- a/include/mapbox/geojsonvt/clip.hpp
+++ b/include/mapbox/geojsonvt/clip.hpp
@@ -112,7 +112,7 @@ private:
             const double ak = get<I>(a);
             const double bk = get<I>(b);
 
-            if (lineMetrics) segLen = std::hypot((b.x - a.x), (b.y - a.y));
+            if (lineMetrics) segLen = ::hypot((b.x - a.x), (b.y - a.y));
 
             if (ak < k1) {
                 if (bk > k2) { // ---|-----|-->

--- a/include/mapbox/geojsonvt/convert.hpp
+++ b/include/mapbox/geojsonvt/convert.hpp
@@ -39,7 +39,7 @@ struct project {
         for (size_t i = 0; i < len - 1; ++i) {
             const auto& a = result[i];
             const auto& b = result[i + 1];
-            result.dist += std::hypot((b.x - a.x), (b.y - a.y));
+            result.dist += ::hypot((b.x - a.x), (b.y - a.y));
         }
 
         simplify(result, tolerance);


### PR DESCRIPTION
Some older STLs (in particular the Android GLIBCXX shipping with GCC 4.9.x) don't have `std::hypot` support yet.