### PR TITLE
Enable undefined behavior sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -I include -std=c++14 -Wall -Wextra -D_GLIBCXX_USE_CXX11_ABI=0
+CXXFLAGS += -I include -fsanitize=undefined -std=c++14 -Wall -Wextra -D_GLIBCXX_USE_CXX11_ABI=0
 RELEASE_FLAGS ?= -O3 -DNDEBUG
 DEBUG_FLAGS ?= -g -O0 -DDEBUG
 


### PR DESCRIPTION
Enabling the `-fsanitize=undefined` compiler flag shows a division by zero
`include/mapbox/geojsonvt/convert.hpp:27:64: runtime error: division by zero`

cc @pozdnyakov 