### PR TITLE
Generate geometry hash during Tile creation

### DIFF
--- a/include/mapbox/geojsonvt/tile.hpp
+++ b/include/mapbox/geojsonvt/tile.hpp
@@ -4,13 +4,220 @@
 #include <cmath>
 #include <mapbox/geojsonvt/types.hpp>
 
+// ToDo: move into geometry.hpp once dependent projects upgrade to geometry.hpp v2
+namespace  {
+template <class... Ts> void ignore(Ts&&...) {}
+
+template <class T> void ignore(const std::initializer_list<T>&) {}
+
+// Handle the zero-argument case.
+inline void ignore(const std::initializer_list<int>&) {}
+
+inline void combine_hashes(std::size_t& seed, const std::size_t hash) {
+    seed ^= hash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template <class T>
+void hash_combine(std::size_t& seed, const T& v) {
+    combine_hashes(seed, std::hash<T>{}(v));
+}
+
+template <class... Args>
+std::size_t hash(Args&&... args) {
+    std::size_t seed = 0;
+    ignore({ (hash_combine(seed, args), 0)... });
+    return seed;
+}
+
+const std::size_t kArrayHash = hash(std::string{"Array"});
+const std::size_t kNullValueHash = hash(std::numeric_limits<double>::quiet_NaN());
+const std::size_t kMapHash = hash(std::string{"Map"});
+const std::size_t kGeometryHash = hash(std::string{"geometry"});
+const std::size_t kGeometriesHash = hash(std::string{"geometries"});
+const std::size_t kCoordinatesHash = hash(std::string{"coordinates"});
+const std::size_t kFeatureHash = hash(std::string{"Feature"});
+const std::size_t kFeaturesHash = hash(std::string{"Features"});
+const std::size_t kIdHash = hash(std::string{"id"});
+const std::size_t kPropertiesHash = hash(std::string{"properties"});
+const std::size_t kFeatureCollectionHash = hash(std::string{"FeatureCollection"});
+
+struct ValueHasher {
+    std::size_t operator()(mapbox::feature::null_value_t) {
+        // TODO: choose a proper value to represent null value
+        return kNullValueHash;
+    }
+
+    std::size_t operator()(bool t) { return hash(t); }
+
+    std::size_t operator()(int64_t t) { return hash(t); }
+
+    std::size_t operator()(uint64_t t) { return hash(t); }
+
+    std::size_t operator()(double t) { return hash(t); }
+
+    std::size_t operator()(const std::string& t) { return hash(t); }
+
+    std::size_t operator()(const std::vector<::mapbox::feature::value>& array) {
+        std::size_t seed{0};
+        // Represent Array starts
+        combine_hashes(seed, kArrayHash);
+        for (const auto& item : array) {
+            hash_combine(seed, ::mapbox::feature::value::visit(item, *this));
+        }
+        return seed;
+    }
+
+    std::size_t operator()(const std::unordered_map<std::string, ::mapbox::feature::value>& map) {
+        std::size_t seed{0};
+        // Represent map starts
+        combine_hashes(seed, kMapHash);
+        for (const auto& property : map) {
+            hash_combine(seed, property.first);
+            hash_combine(seed, ::mapbox::feature::value::visit(property.second, *this));
+        }
+        return seed;
+    }
+};
+
+struct to_type {
+public:
+    const char* operator()(const mapbox::geometry::empty&) { return "Empty"; }
+
+    const char* operator()(const mapbox::geometry::point<int16_t>&) { return "Point"; }
+
+    const char* operator()(const mapbox::geometry::line_string<int16_t>&) { return "LineString"; }
+
+    const char* operator()(const mapbox::geometry::polygon<int16_t>&) { return "Polygon"; }
+
+    const char* operator()(const mapbox::geometry::multi_point<int16_t>&) { return "MultiPoint"; }
+
+    const char* operator()(const mapbox::geometry::multi_line_string<int16_t>&) { return "MultiLineString"; }
+
+    const char* operator()(const mapbox::geometry::multi_polygon<int16_t>&) { return "MultiPolygon"; }
+
+    const char* operator()(const mapbox::geometry::geometry_collection<int16_t>&) { return "GeometryCollection"; }
+};
+
+struct GeometryHasher {
+    // Handles line_string, polygon, multi_point, multi_line_string, multi_polygon, and geometry_collection.
+    template <class E>
+    std::size_t unwrap_vector(const std::vector<E>& vector) {
+        std::size_t seed{0};
+        // Represent Array starts
+        combine_hashes(seed, kArrayHash);
+        for (const auto& item : vector) {
+            hash_combine(seed, operator()(item));
+        }
+        return seed;
+    }
+
+    std::size_t operator()(const mapbox::geometry::line_string<int16_t>& element) {
+        return unwrap_vector(element);
+    }
+
+    std::size_t operator()(const mapbox::geometry::polygon<int16_t>& element) {
+        return unwrap_vector(element);
+    }
+
+    std::size_t operator()(const mapbox::geometry::multi_point<int16_t>& element) {
+        return unwrap_vector(element);
+    }
+
+    std::size_t operator()(const mapbox::geometry::multi_line_string<int16_t>& element) {
+        return unwrap_vector(element);
+    }
+
+    std::size_t operator()(const mapbox::geometry::multi_polygon<int16_t>& element) {
+        return unwrap_vector(element);
+    }
+
+    std::size_t operator()(const mapbox::geometry::geometry_collection<int16_t>& element) {
+        return unwrap_vector(element);
+    }
+
+    std::size_t operator()(const mapbox::geometry::linear_ring<int16_t>& element) {
+        return unwrap_vector(element);
+    }
+
+    std::size_t operator()(const mapbox::geometry::point<int16_t>& element) {
+        return hash(element.x, element.y);
+    }
+
+    std::size_t operator()(const mapbox::geometry::empty&) {
+        return kNullValueHash;
+    }
+
+    std::size_t operator()(const mapbox::geometry::geometry<int16_t>& element) {
+        return mapbox::geometry::geometry<int16_t>::visit(element, *this);
+    }
+};
+
+
+std::size_t getHash(const mapbox::geometry::geometry<int16_t>& element) {
+    std::size_t seed{0};
+    hash_combine(seed, mapbox::geometry::geometry<int16_t>::visit(element, to_type()));
+    combine_hashes(seed,
+                               element.is<mapbox::geometry::geometry_collection<int16_t>>() ? kGeometriesHash : kCoordinatesHash);
+    hash_combine(seed, mapbox::geometry::geometry<int16_t>::visit(element, GeometryHasher{}));
+
+    return seed;
+}
+
+std::size_t getHash(const mapbox::feature::feature<int16_t>& element) {
+    std::size_t seed{0};
+    combine_hashes(seed, kFeatureHash);
+
+    if (!element.id.is<mapbox::feature::null_value_t>()) {
+        combine_hashes(seed, kIdHash);
+        hash_combine(seed, mapbox::feature::identifier::visit(element.id, ValueHasher{}));
+    }
+    combine_hashes(seed, kGeometryHash);
+    hash_combine(seed, getHash(element.geometry));
+    combine_hashes(seed, kPropertiesHash);
+    hash_combine(seed, ValueHasher{}(element.properties));
+    return seed;
+}
+
+std::size_t getHash(const mapbox::feature::feature_collection<int16_t>& collection) {
+    std::size_t seed{0};
+    combine_hashes(seed, kFeatureCollectionHash);
+
+    // Represent Array starts
+    combine_hashes(seed, kArrayHash);
+    for (const auto& element : collection) {
+        hash_combine(seed, getHash(element));
+    }
+    combine_hashes(seed, kFeaturesHash);
+
+    return seed;
+}
+
+} // namespace
+
 namespace mapbox {
 namespace geojsonvt {
+
+struct TileKey {
+    uint8_t z;
+    uint32_t x;
+    uint32_t y;
+    size_t digest;
+
+    bool operator==(TileKey const& o) const {
+        return z == o.z && x == o.x && y == o.y && digest == o.digest;
+    }
+};
+
+struct TileFeatures {
+    mapbox::feature::feature_collection<int16_t> features;
+    TileKey key;
+};
 
 struct Tile {
     mapbox::feature::feature_collection<int16_t> features;
     uint32_t num_points = 0;
     uint32_t num_simplified = 0;
+    TileKey key;
 };
 
 namespace detail {
@@ -48,6 +255,9 @@ public:
           sq_tolerance(tolerance_ * tolerance_),
           lineMetrics(lineMetrics_) {
 
+        tile.key.z = z;
+        tile.key.x = x;
+        tile.key.y = y;
         tile.features.reserve(source.size());
         for (const auto& feature : source) {
             const auto& geom = feature.geometry;
@@ -67,6 +277,7 @@ public:
             bbox.max.x = std::max(feature.bbox.max.x, bbox.max.x);
             bbox.max.y = std::max(feature.bbox.max.y, bbox.max.y);
         }
+        tile.key.digest = getHash(tile.features);
     }
 
 private:


### PR DESCRIPTION
This change makes the Tile constructor generate a digest for the contained geometry.

Currently, the generation is forced inside the constructor. It could be however possible to change this and have it optional.