### PR TITLE
Add update feature to geojson-vt-cpp

### DIFF
--- a/include/mapbox/geojsonvt.hpp
+++ b/include/mapbox/geojsonvt.hpp
@@ -6,6 +6,7 @@
 #include <mapbox/geojsonvt/wrap.hpp>
 
 #include <mapbox/feature.hpp>
+#include <mapbox/variant.hpp>
 
 #include <chrono>
 #include <cmath>
@@ -17,6 +18,8 @@ namespace geojsonvt {
 
 using geometry = mapbox::geometry::geometry<double>;
 using feature = mapbox::feature::feature<double>;
+using Update = std::map<mapbox::feature::identifier,
+                        std::list<mapbox::util::variant<mapbox::feature::null_value_t, feature>>>;
 using feature_collection = mapbox::feature::feature_collection<double>;
 using geometry_collection = mapbox::geometry::geometry_collection<double>;
 using geojson = mapbox::util::variant<geometry, feature, feature_collection>;
@@ -57,17 +60,14 @@ struct Options : TileOptions {
     // max number of points per tile in the tile index
     uint32_t indexMaxPoints = 100000;
 
-    // whether to generate feature ids, overriding existing ids  
+    // whether to generate feature ids, overriding existing ids
     bool generateId = false;
 };
 
-const Tile empty_tile{};
+const std::shared_ptr<const Tile> empty_tile =
+        std::make_shared<const Tile>();
 
-inline uint64_t toID(uint8_t z, uint32_t x, uint32_t y) {
-    return (((1ull << z) * y + x) * 32) + z;
-}
-
-inline const Tile geoJSONToTile(const geojson& geojson_,
+inline std::shared_ptr<const Tile> geoJSONToTilePointer(const geojson& geojson_,
                                 uint8_t z,
                                 uint32_t x,
                                 uint32_t y,
@@ -78,7 +78,8 @@ inline const Tile geoJSONToTile(const geojson& geojson_,
     const auto features_ = geojson::visit(geojson_, ToFeatureCollection{});
     auto z2 = 1u << z;
     auto tolerance = (options.tolerance / options.extent) / z2;
-    auto features = detail::convert(features_, tolerance, false);
+    uint64_t genId = 0;
+    auto features = detail::convert<std::vector, std::list>(features_, tolerance, false, genId, false);
     if (wrap) {
         features = detail::wrap(features, double(options.buffer) / options.extent, options.lineMetrics);
     }
@@ -88,12 +89,23 @@ inline const Tile geoJSONToTile(const geojson& geojson_,
         const auto left = detail::clip<0>(features, (x - p) / z2, (x + 1 + p) / z2, -1, 2, options.lineMetrics);
         features = detail::clip<1>(left, (y - p) / z2, (y + 1 + p) / z2, -1, 2, options.lineMetrics);
     }
-    return detail::InternalTile({ features, z, x, y, options.extent, tolerance, options.lineMetrics }).tile;
+    return detail::InternalTile(features, z, x, y, options.extent, tolerance, options.lineMetrics).getTile();
+}
+
+inline const Tile geoJSONToTile(const geojson& geojson_,
+                                       uint8_t z,
+                                       uint32_t x,
+                                       uint32_t y,
+                                       const TileOptions& options = TileOptions(),
+                                       bool wrap = false,
+                                       bool clip = false) {
+    return *geoJSONToTilePointer(geojson_, z, x, y, options, wrap, clip);
 }
 
 class GeoJSONVT {
 public:
     const Options options;
+    uint64_t genId = 0;
 
     GeoJSONVT(const mapbox::feature::feature_collection<double>& features_,
               const Options& options_ = Options())
@@ -101,7 +113,11 @@ public:
 
         const uint32_t z2 = 1u << options.maxZoom;
 
-        auto converted = detail::convert(features_, (options.tolerance / options.extent) / z2, options.generateId);
+        auto converted = detail::convert<std::vector, std::list>(features_,
+                                                                 (options.tolerance / options.extent) / z2,
+                                                                 options.generateId,
+                                                                 genId,
+                                                                 false);
         auto features = detail::wrap(converted, double(options.buffer) / options.extent, options.lineMetrics);
 
         splitTile(features, 0, 0, 0);
@@ -115,17 +131,22 @@ public:
     uint32_t total = 0;
 
     const Tile& getTile(const uint8_t z, const uint32_t x_, const uint32_t y) {
+        const auto &tile = getTilePointer(z,x_,y);
+        return *tile;
+    }
+
+    std::shared_ptr<const Tile> getTilePointer(const uint8_t z, const uint32_t x_, const uint32_t y) {
 
         if (z > options.maxZoom)
             throw std::runtime_error("Requested zoom higher than maxZoom: " + std::to_string(z));
 
         const uint32_t z2 = 1u << z;
         const uint32_t x = ((x_ % z2) + z2) % z2; // wrap tile x coordinate
-        const uint64_t id = toID(z, x, y);
+        const uint64_t id = detail::InternalTile::toID(z, x, y);
 
         auto it = tiles.find(id);
         if (it != tiles.end())
-            return it->second.tile;
+            return it->second.getTile();
 
         it = findParent(z, x, y);
 
@@ -136,11 +157,11 @@ public:
         const auto& parent = it->second;
 
         // drill down parent tile up to the requested one
-        splitTile(parent.source_features, parent.z, parent.x, parent.y, z, x, y);
+        splitTile(parent.source_features.features, parent.z, parent.x, parent.y, z, x, y);
 
         it = tiles.find(id);
         if (it != tiles.end())
-            return it->second.tile;
+            return it->second.getTile();
 
         it = findParent(z, x, y);
         if (it == tiles.end())
@@ -151,6 +172,66 @@ public:
 
     const std::unordered_map<uint64_t, detail::InternalTile>& getInternalTiles() const {
         return tiles;
+    }
+
+    void updateFeatures(const Update &update) {
+        // 1. erase all updates keys from all cached tiles
+        for (auto &t: tiles) {
+            auto &tile = t.second;
+            for (auto u: update) {
+                tile.removeFeature(u.first);
+            }
+        }
+        // 2. Add all features != nullopt
+        // 2.1 Add features to a feature collection to feed to detail::convert, and calculate the bounding box.
+        mapbox::feature::feature_collection<double, std::list> newFeatures;
+        for (auto u: update) {
+            for (auto f: u.second) {
+                if (!f.is<mapbox::feature::null_value_t>()) {
+                    newFeatures.push_back(f.get_unchecked<feature>());
+
+                }
+            }
+        }
+        uint32_t z2 = 1u << options.maxZoom;
+        auto converted = detail::convert(newFeatures,
+                                         (options.tolerance / options.extent) / z2,
+                                         options.generateId,
+                                         genId,
+                                         true);
+        auto features = detail::wrap(converted, double(options.buffer) / options.extent, options.lineMetrics);
+
+        // Calculate the bbox to help with trivial accept/reject
+        mapbox::geometry::box<double> newDataBbox = { { 2, 1 }, { -1, 0 } };
+        for (const auto &f: features) {
+            detail::InternalTile::extendBox(newDataBbox, f.bbox);
+        }
+        const auto& min = newDataBbox.min;
+        const auto& max = newDataBbox.max;
+
+        // 2.2 For all already generated tiles, add clipped newFeatures to those tiles
+        for (auto &t: tiles) {
+            auto &key = t.first;
+            auto &tile = t.second;
+            const auto coords = detail::InternalTile::fromID(key);
+            const auto x = std::get<0>(coords);
+            const auto y = std::get<1>(coords);
+            const auto z = std::get<2>(coords);
+            z2 = 1u << z;
+            const double p = 0.5 * options.buffer / options.extent;
+
+            const auto tileLeft = (x - p) / z2;
+            const auto tileRight = (x + 1 + p) / z2;
+            const auto tileTop = (y - p) / z2;
+            const auto tileBottom = (y + 1 + p) / z2;
+
+            const auto xClipped = detail::clip<0>(features, tileLeft, tileRight, min.x, max.x, options.lineMetrics);
+            const auto xyClipped = detail::clip<1>(xClipped, tileTop, tileBottom, min.y, max.y, options.lineMetrics);
+
+            if (!xyClipped.empty()) {
+                tile.insertFeatures(xyClipped);
+            }
+        }
     }
 
 private:
@@ -169,12 +250,18 @@ private:
             z0--;
             x0 = x0 / 2;
             y0 = y0 / 2;
-            parent = tiles.find(toID(z0, x0, y0));
+            parent = tiles.find(detail::InternalTile::toID(z0, x0, y0));
         }
 
         return parent;
     }
 
+    // splits features from a parent tile to sub-tiles.
+    // z, x, and y are the coordinates of the parent tile
+    // cz, cx, and cy are the coordinates of the target tile
+    //
+    // If no target tile is specified, splitting stops when we reach the maximum
+    // zoom or the number of points is low as specified in the options.
     void splitTile(const detail::vt_features& features,
                    const uint8_t z,
                    const uint32_t x,
@@ -184,7 +271,7 @@ private:
                    const uint32_t cy = 0) {
 
         const double z2 = 1u << z;
-        const uint64_t id = toID(z, x, y);
+        uint64_t id = detail::InternalTile::toID(z, x, y);
 
         auto it = tiles.find(id);
 
@@ -192,9 +279,11 @@ private:
             const double tolerance =
                 (z == options.maxZoom ? 0 : options.tolerance / (z2 * options.extent));
 
+
+
             it = tiles
-                     .emplace(id,
-                              detail::InternalTile{ features, z, x, y, options.extent, tolerance, options.lineMetrics })
+                     .emplace(std::piecewise_construct, std::make_tuple(id),
+                              std::make_tuple(features, z, x, y, options.extent, tolerance, options.lineMetrics))
                      .first;
             stats[z] = (stats.count(z) ? stats[z] + 1 : 1);
             total++;
@@ -209,19 +298,19 @@ private:
         // if it's the first-pass tiling
         if (cz == 0u) {
             // stop tiling if we reached max zoom, or if the tile is too simple
-            if (z == options.indexMaxZoom || tile.tile.num_points <= options.indexMaxPoints) {
-                tile.source_features = features;
+            if (z == options.indexMaxZoom || tile.num_points <= options.indexMaxPoints) {
                 return;
             }
 
         } else { // drilldown to a specific tile;
             // stop tiling if we reached base zoom
-            if (z == options.maxZoom)
+            if (z == options.maxZoom) {
+                tile.source_features.clear();
                 return;
+            }
 
             // stop tiling if it's our target tile zoom
             if (z == cz) {
-                tile.source_features = features;
                 return;
             }
 
@@ -229,7 +318,6 @@ private:
             const double m = 1u << (cz - z);
             if (x != static_cast<uint32_t>(std::floor(cx / m)) ||
                 y != static_cast<uint32_t>(std::floor(cy / m))) {
-                tile.source_features = features;
                 return;
             }
         }
@@ -238,23 +326,28 @@ private:
         const auto& min = tile.bbox.min;
         const auto& max = tile.bbox.max;
 
+        // k1 and k2, just like vt_features, are in mercator coordinates.
         const auto left = detail::clip<0>(features, (x - p) / z2, (x + 0.5 + p) / z2, min.x, max.x, options.lineMetrics);
 
+        // tl
         splitTile(detail::clip<1>(left, (y - p) / z2, (y + 0.5 + p) / z2, min.y, max.y, options.lineMetrics), z + 1,
                   x * 2, y * 2, cz, cx, cy);
+        // bl
         splitTile(detail::clip<1>(left, (y + 0.5 - p) / z2, (y + 1 + p) / z2, min.y, max.y, options.lineMetrics), z + 1,
                   x * 2, y * 2 + 1, cz, cx, cy);
 
         const auto right =
             detail::clip<0>(features, (x + 0.5 - p) / z2, (x + 1 + p) / z2, min.x, max.x, options.lineMetrics);
 
+        // tr
         splitTile(detail::clip<1>(right, (y - p) / z2, (y + 0.5 + p) / z2, min.y, max.y, options.lineMetrics), z + 1,
                   x * 2 + 1, y * 2, cz, cx, cy);
+        // br
         splitTile(detail::clip<1>(right, (y + 0.5 - p) / z2, (y + 1 + p) / z2, min.y, max.y, options.lineMetrics), z + 1,
                   x * 2 + 1, y * 2 + 1, cz, cx, cy);
 
         // if we sliced further down, no need to keep source geometry
-        tile.source_features = {};
+        tile.source_features.clear();
     }
 };
 

--- a/include/mapbox/geojsonvt/clip.hpp
+++ b/include/mapbox/geojsonvt/clip.hpp
@@ -6,6 +6,8 @@ namespace mapbox {
 namespace geojsonvt {
 namespace detail {
 
+// I = 0 -> clip x
+// I = 1 -> clip y
 template <uint8_t I>
 class clipper {
 public:
@@ -259,10 +261,14 @@ private:
  *  ___|___     |     /
  * /   |   \____|____/
  *     |        |
+ *
+ * k1 and k2 are the line coordinates
+ * axis: 0 for x, 1 for y
+ * minAll and maxAll: minimum and maximum coordinate value for all features
  */
 
-template <uint8_t I>
-inline vt_features clip(const vt_features& features,
+template <uint8_t I, template <typename...> class InputCont, template <typename...> class OutputCont = InputCont>
+inline OutputCont<vt_feature> clip(const InputCont<vt_feature>& features,
                         const double k1,
                         const double k2,
                         const double minAll,
@@ -275,8 +281,7 @@ inline vt_features clip(const vt_features& features,
     if (maxAll < k1 || minAll >= k2) // trivial reject
         return {};
 
-    vt_features clipped;
-    clipped.reserve(features.size());
+    OutputCont<vt_feature> clipped;
 
     for (const auto& feature : features) {
         const auto& geom = feature.geometry;

--- a/include/mapbox/geojsonvt/convert.hpp
+++ b/include/mapbox/geojsonvt/convert.hpp
@@ -6,6 +6,7 @@
 #include <mapbox/feature.hpp>
 
 #include <algorithm>
+#include <vector>
 #include <cmath>
 
 namespace mapbox {
@@ -98,14 +99,15 @@ struct project {
     }
 };
 
-inline vt_features convert(const feature::feature_collection<double>& features,
-                           const double tolerance, bool generateId) {
-    vt_features projected;
-    projected.reserve(features.size());
-    uint64_t genId = 0;
+template <template <typename...> class InputCont, template <typename...> class OutputCont = InputCont>
+inline OutputCont<vt_feature> convert(const feature::feature_collection<double, InputCont>& features,
+                           const double tolerance, bool generateId, uint64_t &genId, bool updating) {
+    OutputCont<vt_feature> projected;
+    container_reserve(projected, features.size());
     for (const auto& feature : features) {
         identifier featureId = feature.id;
-        if (generateId) {
+        if (generateId &&
+                (!updating || featureId.is<mapbox::feature::null_value_t>())) {
             featureId = { uint64_t {genId++} };
         }
         projected.emplace_back(

--- a/include/mapbox/geojsonvt/wrap.hpp
+++ b/include/mapbox/geojsonvt/wrap.hpp
@@ -7,7 +7,8 @@ namespace mapbox {
 namespace geojsonvt {
 namespace detail {
 
-inline void shiftCoords(vt_features& features, double offset) {
+template <template <typename...> class Cont>
+inline void shiftCoords(Cont<vt_feature>& features, double offset) {
     for (auto& feature : features) {
         mapbox::geometry::for_each_point(feature.geometry,
                                          [offset](vt_point& point) { point.x += offset; });
@@ -16,7 +17,8 @@ inline void shiftCoords(vt_features& features, double offset) {
     }
 }
 
-inline vt_features wrap(const vt_features& features, double buffer, const bool lineMetrics) {
+template <template <typename...> class InputCont, template <typename...> class OutputCont = InputCont>
+inline OutputCont<vt_feature> wrap(const InputCont<vt_feature>& features, double buffer, const bool lineMetrics) {
     // left world copy
     auto left = clip<0>(features, -1 - buffer, buffer, -1, 2, lineMetrics);
     // right world copy


### PR DESCRIPTION
This commit adds two new methods,  `updateFeatures` and `getTilePointer`, first one updates the content of geojson-vt (including the cached content), second one returns a shared pointer to `const Tile,` instead of a const reference to `Tile`.
The old `getTile` method is left untouched for source compatibility reasons, but it has to be noted that it is incorrect and leading to all sorts of crashes the usage of `getTile` in combination with `updateFeatures`.